### PR TITLE
 switch test match from src folder to root directory

### DIFF
--- a/scripts/utils/createJestConfig.js
+++ b/scripts/utils/createJestConfig.js
@@ -27,8 +27,10 @@ module.exports = (resolve, rootDir, isEjecting) => {
     setupFiles: [resolve('config/polyfills.js')],
     setupTestFrameworkScriptFile: setupTestsFile,
     testMatch: [
-      '<rootDir>/src/**/__tests__/**/*.js?(x)',
-      '<rootDir>/src/**/?(*.)(spec|test).js?(x)',
+      // switch from src folder to root directory
+      // according to this pull request https://github.com/facebookincubator/create-react-app/pull/1808/files
+      '<rootDir>/!(build|docs|node_modules|scripts)/**/__tests__/**/*.js?(x)',
+      '<rootDir>/!(build|docs|node_modules|scripts)/**/?(*.)(spec|test).js?(x)',
     ],
     testEnvironment: 'node',
     testURL: 'http://localhost',


### PR DESCRIPTION
把 testMatch 的 pattern 從只看 src 資料夾下面的 test 改成看所有 test，之後可以再用 `testPathPattern` 指定特定資料夾（例如 `src`、`test` 等）